### PR TITLE
add scnlib v2.0.0 to libraries.yaml

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1861,6 +1861,7 @@ libraries:
       targets:
       - '0.4'
       - 1.1.2
+      - v2.0.0
       type: github
     seastar:
       check_file: README.md


### PR DESCRIPTION
This adds version v2.0.0 to scnlib, which is the lastest tagged version in https://github.com/eliaskosunen/scnlib/tags